### PR TITLE
Add cross-platform CMake build script.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,292 @@
+# Set minimum CMake required version for this project.
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+
+# Define a C++ project.
+project(RtAudio LANGUAGES CXX)
+
+# standards version
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Check for Jack (any OS)
+find_library(JACK_LIB jack)
+find_package(PkgConfig)
+pkg_check_modules(jack jack)
+if(JACK_LIB OR jack_FOUND)
+  set(HAVE_JACK TRUE)
+endif()
+
+# Check for Pulse (any OS)
+pkg_check_modules(pulse libpulse-simple)
+
+# Check for known non-Linux unix-likes
+if(CMAKE_SYSTEM_NAME MATCHES "kNetBSD.*|NetBSD.*")
+  message(STATUS "NetBSD detected, using OSS")
+  set(xBSD ON)
+elseif(UNIX AND NOT APPLE)
+  set(LINUX ON)
+endif()
+
+# Necessary for Windows
+if(MINGW)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
+# Standard CMake options
+option(BUILD_SHARED_LIBS "Build as shared library" OFF)
+
+if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug;Release;RelWithDebInfo;MinSizeRel")
+endif()
+if(WIN32)
+  set(CMAKE_DEBUG_POSTFIX d CACHE STRING "Postfix for debug version of library")
+endif()
+
+# API Options
+option(RTAUDIO_API_DS "Build DirectSound API" OFF)
+option(RTAUDIO_API_ASIO "Build ASIO API" OFF)
+option(RTAUDIO_API_WASAPI "Build WASAPI API" ${WIN32})
+option(RTAUDIO_API_OSS "Build OSS4 API" ${xBSD})
+option(RTAUDIO_API_ALSA "Build ALSA API" ${LINUX})
+option(RTAUDIO_API_PULSE "Build PulseAudio API" ${pulse_FOUND})
+option(RTAUDIO_API_JACK "Build JACK audio server API" ${HAVE_JACK})
+option(RTAUDIO_API_CORE "Build CoreAudio API" ${APPLE})
+
+# Check for functions
+include(CheckFunctionExists)
+check_function_exists(gettimeofday HAVE_GETTIMEOFDAY)
+if(HAVE_GETTIMEOFDAY)
+  add_definitions(-DHAVE_GETTIMEOFDAY)
+endif()
+
+# Add -Wall if possible
+if(CMAKE_COMPILER_IS_GNUCXX)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+endif(CMAKE_COMPILER_IS_GNUCXX)
+
+# Add debug flags
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  add_definitions(-D__RTAUDIO_DEBUG__)
+  if(CMAKE_COMPILER_IS_GNUCXX)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+  endif(CMAKE_COMPILER_IS_GNUCXX)
+endif()
+
+# Init variables
+set(rtaudio_SOURCES RtAudio.cpp RtAudio.h)
+set(LINKLIBS)
+set(PKGCONFIG_REQUIRES)
+set(API_DEFS)
+set(API_LIST)
+
+# Tweak API-specific configuration.
+
+# Jack
+if(RTAUDIO_API_JACK AND jack_FOUND)
+  set(NEED_PTHREAD ON)
+  list(APPEND PKGCONFIG_REQUIRES "jack")
+  list(APPEND API_DEFS "-D__UNIX_JACK__")
+  list(APPEND API_LIST "jack")
+  if(jack_FOUND)
+    list(APPEND LINKLIBS ${jack_LIBRARIES})
+    list(APPEND INCDIRS ${jack_INCLUDEDIR})
+  else()
+    list(APPEND LINKLIBS ${JACK_LIB})
+  endif()
+endif()
+
+# ALSA
+if(RTAUDIO_API_ALSA)
+  set(NEED_PTHREAD ON)
+  find_package(ALSA)
+  if(NOT ALSA_FOUND)
+    message(FATAL_ERROR "ALSA API requested but no ALSA dev libraries found")
+  endif()
+  list(APPEND INCDIRS ${ALSA_INCLUDE_DIR})
+  list(APPEND LINKLIBS ${ALSA_LIBRARY})
+  list(APPEND PKGCONFIG_REQUIRES "alsa")
+  list(APPEND API_DEFS "-D__LINUX_ALSA__")
+  list(APPEND API_LIST "alsa")
+endif()
+
+# OSS
+if(RTAUDIO_OSS)
+  set(NEED_PTHREAD ON)
+  find_library(OSSAUDIO_LIB ossaudio)
+  if(OSSAUDIO_LIB)
+    list(APPEND LINKLIBS ossaudio)
+    # Note: not an error on some systems
+  endif()
+  list(APPEND API_DEFS "-D__LINUX_OSS__")
+  list(APPEND API_LIST "oss")
+endif()
+
+# Pulse
+if(RTAUDIO_API_PULSE)
+  set(NEED_PTHREAD ON)
+  find_library(PULSE_LIB pulse)
+  find_library(PULSESIMPLE_LIB pulse-simple)
+  list(APPEND LINKLIBS ${PULSE_LIB} ${PULSESIMPLE_LIB})
+  list(APPEND PKGCONFIG_REQUIRES "libpulse-simple")
+  list(APPEND API_DEFS "-D__LINUX_PULSE__")
+  list(APPEND API_LIST "pulse")
+endif()
+
+# CoreAudio
+if(RTAUDIO_API_CORE)
+  find_library(COREAUDIO_LIB CoreAudio)
+  find_library(COREFOUNDATION_LIB CoreFoundation)
+  list(APPEND LINKLIBS ${COREAUDIO_LIB} ${COREFOUNDATION_LIB})
+  list(APPEND API_DEFS "-D__MACOSX_CORE__")
+  list(APPEND API_LIST "core")
+endif()
+
+# ASIO
+if(RTAUDIO_API_ASIO)
+  set(NEED_WIN32LIBS ON)
+  include_directories(include)
+  list(APPEND rtaudio_SOURCES
+    include/asio.cpp
+    include/asiodrivers.cpp
+    include/asiolist.cpp
+    include/iasiothiscallresolver.cpp)
+  list(APPEND API_DEFS "-D__WINDOWS_ASIO__")
+  list(APPEND API_LIST "asio")
+endif()
+
+# DSound
+if(RTAUDIO_API_DS)
+  set(NEED_WIN32LIBS ON)
+  list(APPEND LINKLIBS dsound)
+  list(APPEND API_DEFS "-D__WINDOWS_DS__")
+  list(APPEND API_LIST "ds")
+endif()
+
+# WASAPI
+if(RTAUDIO_API_WASAPI)
+  include_directories(include)
+  set(NEED_WIN32LIBS ON)
+  list(APPEND LINKLIBS ksuser mfplat mfuuid wmcodecdspuuid)
+  list(APPEND API_DEFS "-D__WINDOWS_WASAPI__")
+  list(APPEND API_LIST "wasapi")
+endif()
+
+# Windows libs
+if(NEED_WIN32LIBS)
+  list(APPEND LINKLIBS winmm ole32)
+endif()
+
+# pthread
+if(NEED_PTHREAD)
+  find_package(Threads REQUIRED
+    CMAKE_THREAD_PREFER_PTHREAD
+    THREADS_PREFER_PTHREAD_FLAG)
+  list(APPEND LINKLIBS Threads::Threads)
+endif()
+
+# Create library targets.
+set(LIB_TARGETS)
+
+# Use RTAUDIO_BUILD_SHARED_LIBS / RTAUDIO_BUILD_STATIC_LIBS if they
+# are defined, otherwise default to standard BUILD_SHARED_LIBS.
+if(DEFINED RTAUDIO_BUILD_SHARED_LIBS)
+  if(RTAUDIO_BUILD_SHARED_LIBS)
+    add_library(rtaudio SHARED ${rtaudio_SOURCES})
+  else()
+    add_library(rtaudio STATIC ${rtaudio_SOURCES})
+    set(RTAUDIO_IS_STATIC TRUE)
+  endif()
+elseif(DEFINED RTAUDIO_BUILD_STATIC_LIBS)
+  if(RTAUDIO_BUILD_STATIC_LIBS)
+    add_library(rtaudio STATIC ${rtaudio_SOURCES})
+    set(RTAUDIO_IS_STATIC TRUE)
+  else()
+    add_library(rtaudio SHARED ${rtaudio_SOURCES})
+  endif()
+else()
+  add_library(rtaudio ${rtaudio_SOURCES})
+  if(NOT BUILD_SHARED_LIBS)
+    set(RTAUDIO_IS_STATIC TRUE)
+  endif()
+endif()
+list(APPEND LIB_TARGETS rtaudio)
+
+if(NOT DEFINED RTAUDIO_STATIC_MSVCRT)
+  set(RTAUDIO_STATIC_MSVCRT ${RTAUDIO_IS_STATIC})
+endif()
+
+# In MSVC, set MD/MT appropriately for a static library
+# (From https://github.com/protocolbuffers/protobuf/blob/master/cmake/CMakeLists.txt)
+if(MSVC AND RTAUDIO_STATIC_MSVCRT)
+  foreach(flag_var
+      CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+      CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+    if(${flag_var} MATCHES "/MD")
+      string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+    endif(${flag_var} MATCHES "/MD")
+  endforeach(flag_var)
+endif()
+
+# Add headers destination for install rule.
+set_property(TARGET rtaudio PROPERTY PUBLIC_HEADER RtAudio.h)
+set_target_properties(rtaudio PROPERTIES
+  SOVERSION ${SO_VER}
+  VERSION ${FULL_VER})
+
+# Set standard installation directories.
+include(GNUInstallDirs)
+
+# Set include paths, populate target interface.
+target_include_directories(rtaudio
+  INTERFACE
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/rtaudio>
+  PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    ${INCDIRS}
+)
+
+# Set compile-time definitions
+target_compile_definitions(rtaudio PRIVATE ${API_DEFS})
+target_compile_definitions(rtaudio PRIVATE RTAUDIO_EXPORT)
+target_link_libraries(rtaudio ${LINKLIBS})
+
+# Subdirs
+include(CTest)
+
+if(NOT DEFINED RTAUDIO_BUILD_TESTING OR RTAUDIO_BUILD_TESTING STREQUAL "")
+  set(RTAUDIO_BUILD_TESTING ${BUILD_TESTING})
+endif()
+
+# Message
+string(REPLACE ";" " " apilist "${API_LIST}")
+message(STATUS "Compiling with support for: ${apilist}")
+
+# PkgConfig file
+string(REPLACE ";" " " req "${PKGCONFIG_REQUIRES}")
+string(REPLACE ";" " " api "${API_DEFS}")
+set(prefix ${CMAKE_INSTALL_PREFIX})
+
+# Store the package in the user registry.
+export(PACKAGE RtAudio)
+
+# Create CMake configuration export file.
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/RtAudioConfig.cmake.in "@PACKAGE_INIT@\n")
+
+if(NEED_PTHREAD)
+  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/RtAudioConfig.cmake.in "find_package(Threads REQUIRED)\n")
+endif()
+
+file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/RtAudioConfig.cmake.in "include(\${CMAKE_CURRENT_LIST_DIR}/RtAudioTargets.cmake)")
+
+include_directories(..)
+if (WIN32)
+    include_directories(../include)
+endif (WIN32)
+
+list(GET LIB_TARGETS 0 LIBRTAUDIO)
+
+add_executable(lcc lcc_rtaudio.cpp)
+target_link_libraries(lcc ${LIBRTAUDIO} ${LINKLIBS})
+
+install(FILES ${CMAKE_BINARY_DIR}/lcc DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,6 +279,15 @@ endif()
 
 file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/RtAudioConfig.cmake.in "include(\${CMAKE_CURRENT_LIST_DIR}/RtAudioTargets.cmake)")
 
+# Create uninstall target.                                                                                              
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake" IMMEDIATE @ONLY)
+  
+add_custom_target(
+  uninstall "${CMAKE_COMMAND}" -P
+            "${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake")
+
 include_directories(..)
 if (WIN32)
     include_directories(../include)

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -1,0 +1,26 @@
+if(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+  message(
+    FATAL_ERROR
+      "Cannot find install manifest: '@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt' "
+  )
+endif(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+
+file(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE " " ";" files "${files}")
+
+foreach(file ${files})
+  message(STATUS "Uninstalling '$ENV{DESTDIR}${file}'")
+
+  if(EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS
+      "-E remove '$ENV{DESTDIR}${file}'" OUTPUT_VARIABLE
+      rm_out RETURN_VALUE
+      rm_retval)
+   if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing '$ENV{DESTDIR}${file}'")
+   endif(NOT "${rm_retval}" STREQUAL 0)
+   else(EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File '$ENV{DESTDIR}${file}' does not exist.")
+   endif(EXISTS "$ENV{DESTDIR}${file}")
+endforeach(file)

--- a/lcc_rtaudio.cpp
+++ b/lcc_rtaudio.cpp
@@ -74,7 +74,7 @@ int inout( void *outputBuffer, void *inputBuffer, unsigned int nBufferFrames,
         double outRMS = 0;
         double inRMS = 0;
         double ratioRMS=0;
-        for (int i=0;i<nBufferFrames*2;i+=buflen){
+        for (unsigned int i=0;i<nBufferFrames*2;i+=buflen){
             for (int j=0;j<buflen;j++){
                 in_LR[j]=in_RT_LR[i+j];
             }
@@ -106,7 +106,7 @@ int setupAudioStreams(){
     std::cout << "\nNo audio devices.\n";
     exit( 0 );
   }
-  for (int i=0;i<audio.getDeviceCount();i++){
+  for (unsigned int i=0;i<audio.getDeviceCount();i++){
   	info = audio.getDeviceInfo( i );
   	std::cout << i << ":" << info.name << ", rates:";
   	for(size_t i = 0; i < info.sampleRates.size(); ++i)


### PR DESCRIPTION
This pull request adds support for building lcc on all platforms supported by RtAudio. 

It has been tested on Linux (Jack, ALSA and PulseAudio backends) but it should work as is - or with minor modifications - on Mac OSX (CoreAudio), SGI, NetBSD and Windows (Directsound, ASIO and WASAPI).

The build scripts include targets for installing and uninstalling the binary. 

RtAudio is linked statically so there's no need to install said library.